### PR TITLE
补充遗漏的 `@Arg` 修饰符

### DIFF
--- a/src/resolver/User/UserResolver.ts
+++ b/src/resolver/User/UserResolver.ts
@@ -38,7 +38,7 @@ export class UserResolver implements ResolverInterface<User> {
   }
 
   @Query(() => Boolean)
-  async existUsername(username: string): Promise<boolean> {
+  async existUsername(@Arg("username") username: string): Promise<boolean> {
     return (await this.userRepository.findByUsername(username)) !== undefined;
   }
 


### PR DESCRIPTION
In order to parse in the parameter, `@Arg` decorator is needed. But you missed it accidentally. Please review this commit before you merge it.